### PR TITLE
Add Zstandard source link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,8 @@ Once the PR has been merged, tag the commit as
 ``sqlite-<full version to be used in CPython's PCbuild/get_externals.bat>``.
 
 For updating each project to be updated, follow the above instructions with
-appropriate substitutions.  For ``sqlite``, ``bzip2``, ``xz``, and ``zlib``,
-that's it!
+appropriate substitutions.  For ``sqlite``, ``bzip2``, ``xz``, ``zlib``, and
+``zstd``, that's it!
 
 For ``openssl``, ``tcl``/``tk``, and ``libffi``, builds of each should also be
 checked into `cpython-bin-deps <https://github.com/python/cpython-bin-deps/>`_
@@ -58,6 +58,7 @@ Download links
 - ``tcl``/``tk``: https://tcl.tk/software/tcltk/download.html
 - ``xz``: https://github.com/tukaani-project/xz
 - ``zlib``: https://zlib.net/
+- ``zstd``: https://github.com/facebook/zstd
 
 Tagging the commit
 ------------------


### PR DESCRIPTION
One tricky thing with the zstd sources is that they include Github Actions workflow definitions. I'm not sure if that can be imported as-is without causing actions to start triggering.